### PR TITLE
Main Page 강의평 큐레이션 카드 뷰 (SNUTT-233)

### DIFF
--- a/lib/api/apis.ts
+++ b/lib/api/apis.ts
@@ -1,4 +1,4 @@
-import { ReviewDTO } from "@lib/dto/review"
+import { ReviewDetailDTO, ReviewDTO } from "@lib/dto/review"
 import { SearchResultDTO } from "@lib/dto/searchResult"
 
 export function fetchRecentReviews(): Promise<ReviewDTO[]> {
@@ -58,6 +58,40 @@ export function requestSearch(): Promise<SearchResultDTO[]> {
             grade: "석사",
             lecturer: "서정록",
             rating: 1.8,
+          },
+        ]),
+      1000,
+    )
+  })
+}
+
+export function fetchMainReviews(): Promise<ReviewDetailDTO[]> {
+  return new Promise((resolve) => {
+    setTimeout(
+      () =>
+        resolve([
+          {
+            id: "1",
+            name: "편집디자인",
+            point: 1,
+            semester: "2021-1",
+            contents: "짧은 리뷰",
+          },
+          {
+            id: "2",
+            name: "편집디자인",
+            point: 1,
+            semester: "2021-1",
+            contents:
+              "긴 리뷰. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요.강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요.강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. ",
+          },
+          {
+            id: "3",
+            name: "편집디자인",
+            point: 1,
+            semester: "2021-1",
+            contents:
+              "중간 리뷰. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요. 강의평 내용을 입력하세요 ",
           },
         ]),
       1000,

--- a/lib/components/Text/Detail.ts
+++ b/lib/components/Text/Detail.ts
@@ -7,7 +7,7 @@ export const Detail = styled.p`
   font-family: AppleSDGothicNeo;
   font-weight: normal;
   font-size: 12px;
-  line-height: 14.5px;
+  line-height: 15px;
   color: ${COLORS.black};
 `
 
@@ -16,6 +16,6 @@ export const DetailHighlight = styled.p`
   font-family: AppleSDGothicNeo;
   font-weight: bold;
   font-size: 12px;
-  line-height: 14.5px;
+  line-height: 15px;
   color: ${COLORS.black};
 `

--- a/lib/dto/review.ts
+++ b/lib/dto/review.ts
@@ -3,3 +3,8 @@ export interface ReviewDTO {
   name: string
   point: number
 }
+
+export interface ReviewDetailDTO extends ReviewDTO {
+  semester: string
+  contents: string
+}

--- a/lib/styles/colors.ts
+++ b/lib/styles/colors.ts
@@ -1,3 +1,5 @@
 export const COLORS = {
   black: "#000000",
+  gray: "#F2F2F2",
+  darkGray: "rgba(119, 119, 119, 1)",
 }

--- a/pageImpl/mainImpl/__components__/ReviewCard.tsx
+++ b/pageImpl/mainImpl/__components__/ReviewCard.tsx
@@ -1,0 +1,71 @@
+import styled from "@emotion/styled"
+import { Detail, Subheading01 } from "@lib/components/Text"
+import { COLORS } from "@lib/styles/colors"
+import { ReviewDetailDTO } from "@lib/dto/review"
+
+interface Props {
+  review: ReviewDetailDTO
+}
+
+export const ReviewCard = ({ review }: Props) => {
+  return (
+    <Wrapper>
+      <Contents>
+        <Header>
+          <LectureName>{review.name}</LectureName>
+          <SideInfo>
+            <Detail>별이 들어갈 자리</Detail>
+            <Semester>{review.semester} 수강</Semester>
+          </SideInfo>
+        </Header>
+        <Review>
+          <Detail>{review.contents}</Detail>
+        </Review>
+      </Contents>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 140px;
+  padding: 20px 20px 5px 20px;
+  box-sizing: border-box;
+`
+
+const Contents = styled.div`
+  border-bottom: 1px solid ${COLORS.gray};
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 4px;
+`
+
+const Header = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+`
+
+const LectureName = Subheading01
+
+const Semester = styled(Detail)`
+  color: ${COLORS.darkGray};
+`
+
+const SideInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const Review = styled.div`
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+`

--- a/pageImpl/mainImpl/__containers__/index.ts
+++ b/pageImpl/mainImpl/__containers__/index.ts
@@ -1,0 +1,13 @@
+import { fetchMainReviews } from "@lib/api/apis"
+import { useQuery } from "react-query"
+
+export function useMainReviewContainer() {
+  const querySearch = useQuery("reviews/curation", fetchMainReviews)
+
+  const { data, error } = querySearch
+
+  return {
+    data,
+    error,
+  }
+}

--- a/pageImpl/mainImpl/index.tsx
+++ b/pageImpl/mainImpl/index.tsx
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled"
+import { ReviewCard } from "./__components__/ReviewCard"
+import { useMainReviewContainer } from "./__containers__"
+import { Subheading02 } from "@lib/components/Text"
+
+export const MainImpl = () => {
+  const { data } = useMainReviewContainer()
+
+  return (
+    <Wrapper>
+      {data ? (
+        data.map((it) => <ReviewCard review={it} key={it.id} />)
+      ) : (
+        <Subheading02>데이터 로딩 OR 에러</Subheading02>
+      )}
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div``
+
+const SearchResultList = styled.div`
+  padding-left: 20px;
+  padding-right: 20px;
+`
+
+const SearchNoResult = styled.div`
+  font-size: 16px;
+  color: #777777;
+`

--- a/pages/main/index.tsx
+++ b/pages/main/index.tsx
@@ -1,0 +1,6 @@
+import React from "react"
+import { MainImpl } from "@pageImpl/mainImpl"
+
+export default function SearchView() {
+  return <MainImpl />
+}


### PR DESCRIPTION
### 한 것
- /main 에 들어갈 메인 페이지 컴포넌트 생성
- main review mock 데이터 생성
- main page 아랫 부분(리뷰 큐레이션)에 들어갈 카드뷰 생성

TODO : 별은 다른 PR로 만들게요

### 제안할 것
- react-query를 통해 api fetch를 하면 세 상태(data, isLoading, error)를 얻을 수 있는데, isLoading, error를 처리하는 방법으로 React Suspense를 도입하면 어떨까 해요. 컨테이너마다 error, loading 상태에 대한 처리를 매번 해주지 않고 하나의 Provider 로 감싸서 처리해줄 수 있다고 합니다. 
 관련 자료로, https://ko.reactjs.org/docs/concurrent-mode-suspense.html, https://react-query.tanstack.com/guides/suspense
- /pages 에서 각 페이지는 /pages/{이름}/index.tsx 로, 디렉토리로 분류하면 좋을 것 같습니다.

그리고 현재 mock api를 사용해서 컴포넌트를 테스트하고 있는데, mock을 이용해 테스트 코드도 만들어보면 어떨지 생각중

`/main`
<img width="482" alt="Screen Shot 2021-11-13 at 3 36 52 PM" src="https://user-images.githubusercontent.com/54926767/141608849-dcc9181d-2cce-42d8-af86-3a7cce483ca4.png">
