### PR TITLE
temp dev api url as prod

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=https://snutt-api.wafflestudio.com/ev-service/v1
+NEXT_PUBLIC_API_URL=https://snutt-api-dev.wafflestudio.com/ev-service/v1


### PR DESCRIPTION
Dev 배포 위해 임시로 url 변경. 이건 main으로 바로 머지 되지는 않을 것. .env 파일을 github secret으로 넣어야겠다