### PR TITLE
[SNUTT-388] newline 이슈

### DIFF
--- a/lib/components/CollapsableText/index.tsx
+++ b/lib/components/CollapsableText/index.tsx
@@ -14,7 +14,7 @@ export const CollapsableText: React.FC<Props> = ({ text, truncBy = 120 }) => {
     text.length > truncBy && !expanded ? text.slice(0, truncBy) + "..." : text
 
   return (
-    <Detail style={{ overflowWrap: "break-word" }}>
+    <Detail style={{ overflowWrap: "break-word", whiteSpace: "pre-wrap" }}>
       {renderedText}
       {text.length > truncBy && (
         <MoreLessButton onClick={() => setExpanded((status) => !status)}>


### PR DESCRIPTION
### 문제 내용
api 응답으로는 `"강의평 첫줄 \n 강의평 둘째 줄" `이렇게 `'\n'`이 포함된 스트링으로 오는데, 이걸 `review.content`와 같은 방식으로 object 안으로 들어가면
```
'강의평 첫줄
강의평 둘째 줄'
```
이런 식으로 \n이 (console.log 상에서) 사라진 string으로 형태가 달라지네요. 근데 이때도 `content.find('\n')` 같이 \n 검색하며 나오긴 합니다. 뭔가 오묘한 string, new line, escape string 로직에 의한 이슈인 것 같은데 정확한 원인은 모르겠어요

### 해결 내용
위와 같이 \n이 없는 new line string 형태일 때 CSS whitespace 속성으로 new line 적용이 가능하네요. `pre-wrap`은 tab과 new line을 적용한다는 뜻입니다. [링크](https://stackoverflow.com/questions/39325414/line-break-in-html-with-n)

![Screen Shot 2022-04-02 at 12 26 30 PM](https://user-images.githubusercontent.com/54926767/161364136-a8d3cd48-e9fa-415a-a6d5-f16d9028ebc4.png)
