### PR TITLE
Email verification Logic

### DIFF
--- a/lib/api/apis.ts
+++ b/lib/api/apis.ts
@@ -26,20 +26,35 @@ import {
   PostReportEvaluationParams,
   PostReportEvaluationResult,
 } from "@lib/dto/postReportEvaluation"
+import { GetEmailVerificationResult } from "@lib/dto/getEmailVerification"
+import {
+  PostEmailVerificationCodeParams,
+  PostEmailVerificationCodeResult,
+} from "@lib/dto/PostEmailVerification"
+import {
+  PostEmailVerificationParams,
+  PostEmailVerificationResult,
+} from "@lib/dto/PostEmailVerification"
+
+const evServiceBaseEndpoint = "/ev-service/v1"
 
 export async function fetchLatestLectures(): Promise<GetLatestLecturesResult> {
-  return SnuttApi.get<GetLatestLecturesResult>("/users/me/lectures/latest")
+  return SnuttApi.get<GetLatestLecturesResult>(
+    evServiceBaseEndpoint + "/users/me/lectures/latest",
+  )
 }
 
 export async function fetchTagInfos(): Promise<GetTagInfosProcessedResult> {
-  return SnuttApi.get<GetTagInfosProcessedResult>("/tags/search")
+  return SnuttApi.get<GetTagInfosProcessedResult>(
+    evServiceBaseEndpoint + "/tags/search",
+  )
 }
 
 export async function fetchSemesterLectures(
   id: number,
 ): Promise<GetSemesterLecturesResult> {
   return SnuttApi.get<GetSemesterLecturesResult>(
-    `/lectures/${id}/semester-lectures`,
+    evServiceBaseEndpoint + `/lectures/${id}/semester-lectures`,
   )
 }
 
@@ -47,7 +62,10 @@ export async function postLectureEvaluation(
   id: number,
   query: PostEvaluationQuery,
 ): Promise<PostEvaluationResult> {
-  return SnuttApi.post(`/semester-lectures/${id}/evaluations`, query)
+  return SnuttApi.post(
+    evServiceBaseEndpoint + `/semester-lectures/${id}/evaluations`,
+    query,
+  )
 }
 
 export async function fetchLectureEvaluations(
@@ -55,7 +73,7 @@ export async function fetchLectureEvaluations(
   params: GetEvaluationsQuery,
 ): Promise<GetEvaluationsResult> {
   return SnuttApi.get<GetEvaluationsResult>(
-    `/lectures/${id}/evaluations`,
+    evServiceBaseEndpoint + `/lectures/${id}/evaluations`,
     params,
   )
 }
@@ -64,7 +82,7 @@ export async function fetchMyLectureEvaluations(
   id: number,
 ): Promise<GetMyEvaluationsResult> {
   return SnuttApi.get<GetMyEvaluationsResult>(
-    `/lectures/${id}/evaluations/users/me`,
+    evServiceBaseEndpoint + `/lectures/${id}/evaluations/users/me`,
   )
 }
 
@@ -72,18 +90,23 @@ export async function fetchEvaluationSummary(
   id: number,
 ): Promise<GetEvaluationSummaryResponse> {
   return SnuttApi.get<GetEvaluationSummaryResponse>(
-    `/lectures/${id}/evaluation-summary`,
+    evServiceBaseEndpoint + `/lectures/${id}/evaluation-summary`,
   )
 }
 
 export function getLectures(
   query: GetLecturesQuery,
 ): Promise<GetLecturesResult> {
-  return SnuttApi.get<GetLecturesResult>("/lectures", query)
+  return SnuttApi.get<GetLecturesResult>(
+    evServiceBaseEndpoint + "/lectures",
+    query,
+  )
 }
 
 export function getMainTagInfos(): Promise<GetMainTagInfosResult> {
-  return SnuttApi.get<GetMainTagInfosResult>("/tags/main")
+  return SnuttApi.get<GetMainTagInfosResult>(
+    evServiceBaseEndpoint + "/tags/main",
+  )
 }
 
 export function getMainTagEvaluations(
@@ -91,14 +114,14 @@ export function getMainTagEvaluations(
   query: GetMainTagEvalutionsQuery,
 ): Promise<GetMainTagEvaluationsResult> {
   return SnuttApi.get<GetMainTagEvaluationsResult, GetMainTagEvalutionsQuery>(
-    `/tags/main/${id}/evaluations`,
+    evServiceBaseEndpoint + `/tags/main/${id}/evaluations`,
     query,
   )
 }
 
 export function deleteEvaluation(id: number): Promise<DeleteEvaluationResult> {
   return SnuttApi.delete<DeleteEvaluationResult, DeleteEvaluationParams>(
-    `/evaluations/${id}`,
+    evServiceBaseEndpoint + `/evaluations/${id}`,
     {},
   )
 }
@@ -108,7 +131,29 @@ export function postReportEvaluation(
   params: PostReportEvaluationParams,
 ): Promise<DeleteEvaluationResult> {
   return SnuttApi.post<PostReportEvaluationResult, PostReportEvaluationParams>(
-    `/evaluations/${id}/report`,
+    evServiceBaseEndpoint + `/evaluations/${id}/report`,
     params,
   )
+}
+
+export function getEmailVerification(): Promise<GetEmailVerificationResult> {
+  return SnuttApi.get<GetEmailVerificationResult>("/user/email/verification")
+}
+
+export function postEmailVerification(
+  params: PostEmailVerificationParams,
+): Promise<PostEmailVerificationResult> {
+  return SnuttApi.post<
+    PostEmailVerificationResult,
+    PostEmailVerificationParams
+  >("/user/email/verification", params)
+}
+
+export function postEmailVerificationCode(
+  params: PostEmailVerificationCodeParams,
+): Promise<PostEmailVerificationCodeResult> {
+  return SnuttApi.post<
+    PostEmailVerificationCodeResult,
+    PostEmailVerificationCodeParams
+  >("/user/email/verification/code", params)
 }

--- a/lib/dto/PostEmailVerification.ts
+++ b/lib/dto/PostEmailVerification.ts
@@ -1,0 +1,13 @@
+export interface PostEmailVerificationParams {
+  email: string
+}
+
+export interface PostEmailVerificationResult {}
+
+export interface PostEmailVerificationCodeParams {
+  code: number
+}
+
+export interface PostEmailVerificationCodeResult {
+  is_email_verified: boolean
+}

--- a/lib/dto/getEmailVerification.ts
+++ b/lib/dto/getEmailVerification.ts
@@ -1,0 +1,3 @@
+export interface GetEmailVerificationResult {
+  is_email_verified: boolean
+}

--- a/lib/hooks/useCookie.ts
+++ b/lib/hooks/useCookie.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react"
+import Cookies from "js-cookie"
+
+export default function useCookie(
+  cookieName: string,
+): [
+  string | null,
+  (newValue: string, options?: Cookies.CookieAttributes) => void,
+  () => void,
+] {
+  const [value, setValue] = useState<string | null>(
+    () => Cookies.get(cookieName) || null,
+  )
+
+  const updateCookie = useCallback(
+    (newValue: string, options?: Cookies.CookieAttributes) => {
+      Cookies.set(cookieName, newValue, options)
+      setValue(newValue)
+    },
+    [cookieName],
+  )
+
+  const deleteCookie = useCallback(() => {
+    Cookies.remove(cookieName)
+    setValue(null)
+  }, [cookieName])
+
+  return [value, updateCookie, deleteCookie]
+}

--- a/pageImpl/mailVerifyImpl/index.tsx
+++ b/pageImpl/mailVerifyImpl/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled"
-import React, { useState } from "react"
+import React, { useState, ChangeEvent } from "react"
 import { AppBar } from "@lib/components/Appbar"
 import {
   Title01,
@@ -135,8 +135,8 @@ export const MailVerifyImpl = ({ setVerification }: Props) => {
             <VerificationNumberInput
               type="number"
               placeholder={"인증번호 6자리를 입력하세요"}
-              onChange={(e) => {
-                setVerificationNumber(e.target.value)
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setVerificationNumber(parseInt(e.target.value))
               }}
             />
             {isVerificationNumberRequested && (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 import type { AppProps } from "next/app"
 import Head from "next/head"
 import {
@@ -10,6 +10,9 @@ import { css, Global } from "@emotion/react"
 import { appleSDGNeo } from "@lib/styles/fonts"
 import { ErrorBoundary } from "react-error-boundary"
 import { ErrorView } from "@lib/components/Error"
+import { MailVerifyImpl } from "@pageImpl/mailVerifyImpl"
+import useCookie from "@lib/hooks/useCookie"
+import { getEmailVerification } from "@lib/api/apis"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,6 +24,47 @@ const queryClient = new QueryClient({
 })
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const [isEmailVerified, updateEmailVerifedCookie, _] =
+    useCookie("email-verified")
+
+  const checkEmailVerification = async () => {
+    const res = await getEmailVerification()
+    if (res.is_email_verified) {
+      updateEmailVerifedCookie("true")
+    } else {
+      updateEmailVerifedCookie("false")
+    }
+  }
+
+  useEffect(() => {
+    checkEmailVerification()
+  }, [])
+
+  if (isEmailVerified === "false") {
+    return (
+      <>
+        <Head>
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+          />
+        </Head>
+        <Global
+          styles={css`
+            html,
+            body {
+              padding: 0;
+              margin: 0 auto;
+              ${appleSDGNeo};
+              max-width: 768px;
+            }
+          `}
+        />
+        <MailVerifyImpl setVerification={updateEmailVerifedCookie} />
+      </>
+    )
+  }
+
   return (
     <>
       <Head>

--- a/pages/mailVerify/index.tsx
+++ b/pages/mailVerify/index.tsx
@@ -1,6 +1,0 @@
-import React from "react"
-import { MailVerifyImpl } from "@pageImpl/mailVerifyImpl"
-
-export default function DetailView() {
-  return <MailVerifyImpl />
-}


### PR DESCRIPTION
### 이메일 인증 로직 추가
- _app.tsx에서 hook으로 email verified 값을 관리하여 최상단에서 메일 인증 component를 실행합니다.
- 앱을 실행할 때 _app.tsx verification api를 보내고, 그 값을 쿠키에 저장합니다. 앱이 처음 실행될 때 한 번만 불러오도록 합니다.
- useEffect가 실행되기 전에 잠깐 main page가 로드될 수 있습니다. 깜빡이면서

hook 은 요거 갖다 씀. 아주 좋네요
https://github.com/streamich/react-use/blob/master/docs/useCookie.md