### PR TITLE
:construction_worker: add lint check with github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - run: yarn install
+    - run: yarn lint
     - run: yarn build


### PR DESCRIPTION
깃헙액션에서 CI 돌도록 합니다.

zero-install 하면 아예 스크립트 가르는게 나을지도? build 랑 lint 랑 (나중에 테스트코드 추가하면 test 도)