### PR TITLE
:building_construction: api client 생성

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ```
 // env.local
-NEXT_PUBLIC_API_URL=https://snutt-api-dev.wafflestudio.com
+NEXT_PUBLIC_API_URL=https://snutt-api-dev.wafflestudio.com # deprecated
+NEXT_PUBLIC_CORE_API_URL=https://snutt-api-dev.wafflestudio.com
+NEXT_PUBLIC_EV_API_URL=https://snutt-api-dev.wafflestudio.com/ev-service
 NEXT_PUBLIC_LOCAL_ACCESS_TOKEN=youraccesstoken
 NEXT_PUBLIC_LOCAL_ACCESS_APIKEY=youraccessapikey
 ```

--- a/lib/api/request.ts
+++ b/lib/api/request.ts
@@ -14,7 +14,22 @@ const token =
   process.env.NEXT_PUBLIC_LOCAL_ACCESS_TOKEN ||
   ""
 
-export const axiosInstance = axios.create({
+const defaultHeaders = {
+  "x-access-token": token,
+  "x-access-apikey": apikey,
+}
+
+export const coreClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_CORE_API_URL,
+  headers: defaultHeaders,
+})
+
+export const evClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_EV_API_URL,
+  headers: defaultHeaders,
+})
+
+const axiosInstance = axios.create({
   baseURL,
   headers: {
     "x-access-token": token,
@@ -22,6 +37,9 @@ export const axiosInstance = axios.create({
   },
 })
 
+/**
+ * @deprecated use each axios client instead
+ */
 const SnuttApi = {
   async get<R, T = any>(
     url: string,


### PR DESCRIPTION
## Summary

[컨텍스트](https://wafflestudio.slack.com/archives/C0PAVPS5T/p1662895399569399)

일단 client 생성해뒀고, 하나씩 하나씩 저걸로 마이그레이션하려고 합니다.
기존의 `SnuttAPI`는 deprecate했습니다.

## After Merge

```env
NEXT_PUBLIC_CORE_API_URL=https://snutt-api-dev.wafflestudio.com
NEXT_PUBLIC_EV_API_URL=https://snutt-api-dev.wafflestudio.com/ev-service
```

이거 두개 github secret 에 등록해야 합니다.