### PR TITLE
:rotating_light: ban-types 린트 옵션 켜기

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,6 @@
   "plugins": ["@typescript-eslint"],
   "root": true,
   "rules": {
-    "@typescript-eslint/ban-types": "warn", // TODO: "error" 로 변경
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-unused-vars": "error",
     "prettier/prettier": [

--- a/lib/hooks/useScrollLoader.ts
+++ b/lib/hooks/useScrollLoader.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react"
 
-export default function useScrollLoader(loadMore: () => {}) {
+export default function useScrollLoader(loadMore: () => void) {
   const loader = useRef(null)
   const handleObserver = useCallback((entries) => {
     const target = entries[0]


### PR DESCRIPTION
`{}` 는 타입으로 활용하지 않습니다.

해당 함수의 경우 훅에서 받아서 파라미터도 넘기지 않고 리턴값도 쓰지 않기 때문에, `() => void` 가 적절한 타입이라고 판단했습니다.