### PR TITLE
🧑‍💻 exhaustive-deps 옵션 error 로 설정

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   "root": true,
   "rules": {
     "@typescript-eslint/no-empty-interface": "off",
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": "error",
+    "react-hooks/exhaustive-deps": "error"
   }
 }

--- a/lib/hooks/useScrollLoader.ts
+++ b/lib/hooks/useScrollLoader.ts
@@ -1,13 +1,14 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useEffect, useRef } from "react"
 
 export default function useScrollLoader(loadMore: () => void) {
   const loader = useRef(null)
-  const handleObserver = useCallback((entries) => {
+
+  const handleObserver: IntersectionObserverCallback = (entries) => {
     const target = entries[0]
     if (target.isIntersecting) {
       loadMore()
     }
-  }, [])
+  }
 
   useEffect(() => {
     const option = {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -27,18 +27,14 @@ function MyApp({ Component, pageProps }: AppProps) {
   const [isEmailVerified, updateEmailVerifedCookie] =
     useCookie("email-verified")
 
-  const checkEmailVerification = async () => {
-    const res = await getEmailVerification()
-    if (res.is_email_verified) {
-      updateEmailVerifedCookie("true")
-    } else {
-      updateEmailVerifedCookie("false")
-    }
-  }
-
   useEffect(() => {
+    const checkEmailVerification = async () => {
+      const res = await getEmailVerification()
+      updateEmailVerifedCookie(`${!!res.is_email_verified}`)
+    }
+
     checkEmailVerification()
-  }, [])
+  }, [updateEmailVerifedCookie])
 
   if (isEmailVerified === null) {
     return


### PR DESCRIPTION
## Summary

최근들어 exhausitive-deps 옵션의 중요성을 더더 깨닫고 있어서, error 로 설정하고 기존 에러들은 픽스합니다.

`useScrollLoader.ts` 의 경우 `useCallback` 자체가 아무 의미 없기 때문에 그냥 제거했습니다.

`_app.ts` 의 경우 함수를 이펙트 안에서 선언하여 dependency 를 해결합니다. 해결하는 김에 로직 좀더 간단하게 쓸 수 있을 거 같아서 수정했습니다.

## Checklist

- [x] 잘 되는지