### PR TITLE
:bricks: app-env 로 local dev prod test 환경 명시

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_CORE_API_URL=https://snutt-api-dev.wafflestudio.com
 NEXT_PUBLIC_EV_API_URL=https://snutt-api-dev.wafflestudio.com/ev-service
+
+NEXT_PUBLIC_APP_ENV=dev

--- a/.env.prod
+++ b/.env.prod
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_CORE_API_URL=https://snutt-api.wafflestudio.com
 NEXT_PUBLIC_EV_API_URL=https://snutt-api.wafflestudio.com/ev-service
+
+NEXT_PUBLIC_APP_ENV=prod

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_APP_ENV=test

--- a/README.md
+++ b/README.md
@@ -23,4 +23,7 @@ NEXT_PUBLIC_LOCAL_ACCESS_APIKEY=youraccessapikey
 
 # enable/disable react-query devtools
 NEXT_PUBLIC_REACT_QUERY_DEVTOOL=true
+
+# app env (local / dev / prod / test)
+NEXT_PUBLIC_APP_ENV=local
 ```

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:test": "NODE_ENV=test next dev",
     "build": "next build",
     "export": "next build && next export",
     "start": "next start",

--- a/src/lib/util/env.ts
+++ b/src/lib/util/env.ts
@@ -1,0 +1,1 @@
+export const APP_ENV = process.env.NEXT_PUBLIC_APP_ENV;


### PR DESCRIPTION
test 환경은 계속 고도화해야 합니다. 장기적으로는 test 로 오픈 시 msw 로 켜져야 합니다.

`yarn dev:test` 로 켜면 test 환경으로 오픈되는데, 현재는 api 모킹이 덜 되어 있는 관계로 시원하게 터집니다.

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/39977696/190844903-834f457f-5225-489d-9cd1-3aa5ac939d27.png">
