### PR TITLE
♻️ search page 리팩토링 & 검색어 없으면 쿼리 안 쏘도록 변경

### DIFF
--- a/src/pageImpl/searchImpl/__components__/SearchOptionSheet/TagList.tsx
+++ b/src/pageImpl/searchImpl/__components__/SearchOptionSheet/TagList.tsx
@@ -7,21 +7,17 @@ import { TagWithColor } from '@/lib/dto/core/tag';
 interface Props {
   tags: TagWithColor[];
   selectedTags: TagWithColor[];
-  onToggleTag: (tag: TagWithColor) => void;
+  onToggleTag: (tag: number) => void;
 }
 
-export const TagList: React.FC<Props> = ({
-  tags,
-  selectedTags,
-  onToggleTag,
-}) => {
+export const TagList = ({ tags, selectedTags, onToggleTag }: Props) => {
   return (
     <Wrapper>
       {tags.map((it) => (
         <TagItem
           isSelected={selectedTags.some((s) => s.name === it.name)}
           key={it.name}
-          onClick={() => onToggleTag(it)}
+          onClick={() => onToggleTag(it.id)}
           text={it.name}
         />
       ))}

--- a/src/pageImpl/searchImpl/__components__/SearchOptionSheet/index.tsx
+++ b/src/pageImpl/searchImpl/__components__/SearchOptionSheet/index.tsx
@@ -12,20 +12,20 @@ import { TagList } from './TagList';
 interface Props {
   selectedTags: TagWithColor[];
   tagGroups: TagGroupWithColor[];
-  onToggleTag: (tag: TagWithColor) => void;
+  onToggleTag: (tag: number) => void;
   isOpened: boolean;
   onClose: () => void;
   onClickSubmit: () => void;
 }
 
-export const SearchOptionSheet: React.FC<Props> = ({
+export const SearchOptionSheet = ({
   selectedTags,
   tagGroups,
   onToggleTag,
   isOpened,
   onClose: onClose,
   onClickSubmit,
-}) => {
+}: Props) => {
   const [selectedTagGroup, setSelectedTagGroup] = useState<TagGroupWithColor>(
     tagGroups[0],
   );

--- a/src/pageImpl/searchImpl/__components__/Searchbar.tsx
+++ b/src/pageImpl/searchImpl/__components__/Searchbar.tsx
@@ -41,7 +41,7 @@ export const Searchbar: React.FC<Props> = ({
         </SearchButton>
         <Input
           placeholder="검색어를 입력하세요"
-          value={textQuery ?? ''}
+          value={textQuery}
           onChange={(e) => {
             onChangeTextQuery(e.target.value);
           }}

--- a/src/pageImpl/searchImpl/__components__/SelectedTagList.tsx
+++ b/src/pageImpl/searchImpl/__components__/SelectedTagList.tsx
@@ -4,18 +4,15 @@ import SvgExitWhite from '@/lib/components/Icons/SvgExitWhite';
 import { TagWithColor } from '@/lib/dto/core/tag';
 
 interface Props {
-  selectedTags: TagWithColor[];
-  onDeleteTag: (tag: TagWithColor) => void;
+  selectedTags: TagWithColor[] | undefined;
+  onDeleteTag: (tag: number) => void;
 }
 
-export const ActiveTagList: React.FC<Props> = ({
-  selectedTags,
-  onDeleteTag,
-}) => {
+export const ActiveTagList = ({ selectedTags = [], onDeleteTag }: Props) => {
   return selectedTags.length === 0 ? null : (
     <Wrapper>
       {selectedTags.map((it) => (
-        <TagItem tag={it} key={it.name} onClick={() => onDeleteTag(it)} />
+        <TagItem tag={it} key={it.name} onClick={() => onDeleteTag(it.id)} />
       ))}
     </Wrapper>
   );

--- a/src/pageImpl/searchImpl/__containers__/useSearchOptions.ts
+++ b/src/pageImpl/searchImpl/__containers__/useSearchOptions.ts
@@ -6,14 +6,15 @@ interface Return {
   currentlyAppliedQuery: CurrentlyAppliedQuery | undefined;
   refreshQueries: () => void;
   toggleTagSelection: (tagID: number) => void;
-  selectedTextQuery: string | undefined;
-  updateTextQuery: (textQuery: string | undefined) => void;
+  selectedTextQuery: string;
+  updateTextQuery: (textQuery: string) => void;
   selectedTagIDs: number[];
 }
 
 export const useSearchOptions = (): Return => {
   const [selectedTagIDs, setSelectedTagIDs] = useState<number[]>([]);
-  const [textQuery, setTextQuery] = useState<string | undefined>();
+  const [searchKey, setSearchKey] = useState<string>('');
+
   const [currentlyAppliedQuery, setCurrentAppliedQuery] =
     useState<CurrentlyAppliedQuery>();
 
@@ -29,7 +30,7 @@ export const useSearchOptions = (): Return => {
   const refreshQueries = () => {
     setCurrentAppliedQuery({
       tags: selectedTagIDs,
-      textQuery: textQuery,
+      textQuery: searchKey,
     });
   };
 
@@ -37,8 +38,8 @@ export const useSearchOptions = (): Return => {
     currentlyAppliedQuery,
     refreshQueries,
     toggleTagSelection,
-    selectedTextQuery: textQuery,
-    updateTextQuery: setTextQuery,
+    selectedTextQuery: searchKey,
+    updateTextQuery: setSearchKey,
     selectedTagIDs,
   };
 };

--- a/src/pageImpl/searchImpl/__containers__/useSearchOptions.ts
+++ b/src/pageImpl/searchImpl/__containers__/useSearchOptions.ts
@@ -1,37 +1,34 @@
 import { useState } from 'react';
 
-import { TagWithColor } from '@/lib/dto/core/tag';
-
-type CurrentlyAppliedQuery = { tags: TagWithColor[]; textQuery?: string };
+type CurrentlyAppliedQuery = { tags: number[]; textQuery?: string };
 
 interface Return {
   currentlyAppliedQuery: CurrentlyAppliedQuery | undefined;
   refreshQueries: () => void;
-  toggleTagSelection: (tag: TagWithColor) => void;
+  toggleTagSelection: (tagID: number) => void;
   selectedTextQuery: string | undefined;
   updateTextQuery: (textQuery: string | undefined) => void;
-  selectedTags: TagWithColor[];
+  selectedTagIDs: number[];
 }
 
 export const useSearchOptions = (): Return => {
-  const [selectedTags, setSelectedTags] = useState<TagWithColor[]>([]);
+  const [selectedTagIDs, setSelectedTagIDs] = useState<number[]>([]);
   const [textQuery, setTextQuery] = useState<string | undefined>();
   const [currentlyAppliedQuery, setCurrentAppliedQuery] =
     useState<CurrentlyAppliedQuery>();
 
-  const toggleTagSelection = (tag: TagWithColor) => {
-    setSelectedTags((prev) => {
-      if (prev?.some((it) => it.name == tag.name)) {
-        return prev.filter((it) => it.name != tag.name);
-      } else {
-        return prev?.concat(tag);
-      }
-    });
+  const toggleTagSelection = (tagID: number) => {
+    const isExist = selectedTagIDs.includes(tagID);
+    const newSelectedTagIDs = isExist
+      ? selectedTagIDs.filter((id) => id !== tagID)
+      : selectedTagIDs.concat(tagID);
+
+    setSelectedTagIDs(newSelectedTagIDs);
   };
 
   const refreshQueries = () => {
     setCurrentAppliedQuery({
-      tags: selectedTags,
+      tags: selectedTagIDs,
       textQuery: textQuery,
     });
   };
@@ -42,6 +39,6 @@ export const useSearchOptions = (): Return => {
     toggleTagSelection,
     selectedTextQuery: textQuery,
     updateTextQuery: setTextQuery,
-    selectedTags,
+    selectedTagIDs,
   };
 };

--- a/src/pageImpl/searchImpl/__containers__/useSearchOptions.ts
+++ b/src/pageImpl/searchImpl/__containers__/useSearchOptions.ts
@@ -2,11 +2,22 @@ import { useState } from 'react';
 
 import { TagWithColor } from '@/lib/dto/core/tag';
 
-export const useSearchOptions = () => {
+type CurrentlyAppliedQuery = { tags: TagWithColor[]; textQuery?: string };
+
+interface Return {
+  currentlyAppliedQuery: CurrentlyAppliedQuery | undefined;
+  refreshQueries: () => void;
+  toggleTagSelection: (tag: TagWithColor) => void;
+  selectedTextQuery: string | undefined;
+  updateTextQuery: (textQuery: string | undefined) => void;
+  selectedTags: TagWithColor[];
+}
+
+export const useSearchOptions = (): Return => {
   const [selectedTags, setSelectedTags] = useState<TagWithColor[]>([]);
   const [textQuery, setTextQuery] = useState<string | undefined>();
   const [currentlyAppliedQuery, setCurrentAppliedQuery] =
-    useState<{ tags: TagWithColor[]; textQuery?: string }>();
+    useState<CurrentlyAppliedQuery>();
 
   const toggleTagSelection = (tag: TagWithColor) => {
     setSelectedTags((prev) => {

--- a/src/pageImpl/searchImpl/__containers__/useSearchResult.ts
+++ b/src/pageImpl/searchImpl/__containers__/useSearchResult.ts
@@ -1,20 +1,22 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { getLectures } from '@/lib/api/apis';
-import { TagDTO } from '@/lib/dto/core/tag';
 
-export const useSearchResult = (selectedTags: TagDTO[], textQuery?: string) => {
+export const useSearchResult = (
+  selectedTagIDs: number[],
+  textQuery?: string,
+) => {
   const {
     data: searchResult,
     isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
   } = useInfiniteQuery(
-    ['lectureSearch', textQuery, selectedTags],
+    ['lectureSearch', textQuery, selectedTagIDs],
     ({ pageParam }) =>
       getLectures({
         query: textQuery,
-        tags: (selectedTags ?? []).map((it) => it.id),
+        tags: selectedTagIDs,
         page: pageParam,
       }),
     {

--- a/src/pageImpl/searchImpl/index.tsx
+++ b/src/pageImpl/searchImpl/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { SearchResultLoading } from '@/lib/components/Miscellaneous/Loading';
 import useScrollLoader from '@/lib/hooks/useScrollLoader';
@@ -19,7 +19,7 @@ import {
 export const SearchImpl = () => {
   const { tagGroups } = useSearchTags();
   const {
-    selectedTags,
+    selectedTagIDs,
     toggleTagSelection,
     currentlyAppliedQuery,
     refreshQueries,
@@ -39,6 +39,14 @@ export const SearchImpl = () => {
     currentlyAppliedQuery === undefined ||
     (currentlyAppliedQuery?.textQuery === '' &&
       currentlyAppliedQuery?.tags.length === 0);
+
+  const selectedTags = useMemo(
+    () =>
+      tagGroups
+        ?.flatMap((group) => group.tags)
+        .filter((tag) => selectedTagIDs.includes(tag.id)),
+    [selectedTagIDs, tagGroups],
+  );
 
   return (
     <Wrapper>

--- a/src/pageImpl/searchImpl/index.tsx
+++ b/src/pageImpl/searchImpl/index.tsx
@@ -63,7 +63,6 @@ export const SearchImpl = () => {
         onDeleteTag={toggleTagSelection}
       />
       <SearchResultList>
-        {/* FIXME: skip api request if input is "" */}
         {isEmptyQuery ? (
           <SearchInitialPage />
         ) : searchResult?.pages[0].content.length !== 0 ? (


### PR DESCRIPTION
- selectedTag 목록을 tag 전체 정보를 저장하고 있었는데, id만 저장하도록 변경했습니다.
- 검색어 초기값을 `''` 로 변경하여, 검색어도 태그도 없는 상태에서 검색 눌렀을 때 전체 쿼리로 검색되는 버그를 픽스했습니다.