### PR TITLE
🚸 검색 후 어디 갔다가 돌아오면 검색 풀리는 현상 개선

### DIFF
--- a/src/pageImpl/searchImpl/__components__/Searchbar.tsx
+++ b/src/pageImpl/searchImpl/__components__/Searchbar.tsx
@@ -9,7 +9,7 @@ import SvgSearchOff from '@/lib/components/Icons/SvgSearchOff';
 
 interface Props {
   toggleOpenSearchSheet: () => void;
-  textQuery?: string;
+  textQuery: string;
   onChangeTextQuery: (text: string) => void;
   onRefreshQuery: () => void;
 }

--- a/src/pageImpl/searchImpl/__containers__/useSearchTags.ts
+++ b/src/pageImpl/searchImpl/__containers__/useSearchTags.ts
@@ -1,21 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
-import { useCallback } from 'react';
 
 import { fetchTagInfos } from '@/lib/api/apis';
 import { GetTagInfosProcessedResult } from '@/lib/dto/getTagInfos';
 
-export function useSearchTags() {
-  const select = useCallback(
-    ({ tag_groups }: GetTagInfosProcessedResult) => ({
-      tag_groups: tag_groups.map(({ color, tags, ...group }) => ({
-        ...group,
-        color,
-        tags: tags.map((tag) => ({ ...tag, color })),
-      })),
-    }),
-    [],
-  );
+const select = ({ tag_groups }: GetTagInfosProcessedResult) => ({
+  tag_groups: tag_groups.map(({ color, tags, ...group }) => ({
+    ...group,
+    color,
+    tags: tags.map((tag) => ({ ...tag, color })),
+  })),
+});
 
+export function useSearchTags() {
   const { data, error, isLoading } = useQuery(['tagInfos'], fetchTagInfos, {
     select,
   });


### PR DESCRIPTION
검색 정보를 url에 저장하여, 어디 갔다가 돌아와도 검색 결과가 유지됩니다. 페이지네이션 결과는 유지 안되는데 그건 어쩔 수 없는 걸로 아는데 추후 개선사항으로 생각해 보겠습니다.

[src/pageImpl/searchImpl/__containers__/useSearchOptions.ts](https://github.com/wafflestudio/SNUTT-web/pull/148/files#diff-6eb9deb96c11fc84cca8e41627f6f90112a8ba23eb8800fa9b36591c777e8809) 파일만 해당 PR과 유관하고, 나머지는 그냥 마이너 개선사항인데 실수로 커밋을 합쳐버렸습니다.

https://user-images.githubusercontent.com/39977696/190915346-ea863604-f157-4783-9d2c-82f94726e357.mov



