### PR TITLE
🚸 custom 500 페이지 추가

### DIFF
--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+import { AppBar } from '@/lib/components/Appbar';
+import SvgTimetableOn from '@/lib/components/Icons/SvgTimetableOn';
+import { SvgWaffleCat } from '@/lib/components/Icons/SvgWaffleCat';
+import { Title01, Title02 } from '@/lib/components/Text';
+
+export default function Custom500() {
+  return (
+    <>
+      <AppBar LeftImage={() => <SvgTimetableOn height={30} width={30} />}>
+        <Title01 style={{ marginLeft: 12 }}>강의평</Title01>
+      </AppBar>
+      <Container>
+        <Title02 style={{ marginBottom: 40, textAlign: 'center' }}>
+          오류가 발생했습니다.
+        </Title02>
+        <SvgWaffleCat />
+        <OurName>@wafflestudio</OurName>
+      </Container>
+    </>
+  );
+}
+
+const Container = styled.div`
+  width: 100%;
+  height: 85vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const OurName = styled.div`
+  font-family: AppleSDGothicNeo;
+  font-size: 9px;
+  margin-top: 25px;
+`;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39977696/192089246-27c556df-8907-4b8f-8e3c-ee7e4e175067.png)

500 상황에서 기존에는 Next.js 기본 500 페이지가 보였는데, 아무래도 커스텀 페이지를 띄워주는 게 그래도 좋을 것 같아서 추가합니다.

별개로 이 페이지가 보였으면 슬랙 노티를 보내는 등의 작업도 되면 좋을 것 같습니다.